### PR TITLE
Store auth data to localStorage

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -12,6 +12,9 @@ import TheHeader from '@/components/layout/TheHeader'
 export default {
   components: {
     TheHeader
+  },
+  created() {
+    this.$store.dispatch('tryLogin')
   }
 }
 </script>


### PR DESCRIPTION
If we store data only in Vuex, when browser is refreshed, then the whole Vue app is restarted and loses the Vuex data. This means **we cannot keep the user logged in even if the auth token is not expired yet**.

- Store auth token and user id to browser's localStorage
- Every time before the Vue app is restarted, check if auth token and user id are saved in localStorage then automatically log the user in.